### PR TITLE
Use built-in Zed remote MCP in README.md snippet

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,9 @@ Use the following config instead.
 ```json
 "context_servers": {
   "mcp-server-linear": { // name can be whatever you want
-    "command": {
-      "path": "npx",
-      "args": [
-        "-y",
-        "mcp-remote",
-        "https://mcp.linear.app/sse"
-      ]
+    "url": "https://mcp.linear.app/mcp",
+    "headers": { // optional, if you don't want to use the OAuth flow
+      "Authorization": "Bearer <your linear token>"
     }
   }
 }


### PR DESCRIPTION
Hi! I tried getting the linear MCP set up through the extension, and could not get it to work, but I had success with directly setting it up with the new native support for remote MCP servers, so I thought I'd upstream the config snippet. It works like the previous mcp-remote based solution, but uses the new native mechanism in Zed instead.

Let me know if that doesn't make sense or if I missed something.